### PR TITLE
Record previous searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules/
+package-lock.json
 /.pnp
 .pnp.js
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "dotenv": "^10.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,27 @@
 import { useEffect, useState } from "react";
-import './App.css';
-import logo from './mlh-prep.png'
+import "./App.css";
+import logo from "./mlh-prep.png";
+require("dotenv").config();
 
 function App() {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [city, setCity] = useState("New York City")
+  const [city, setCity] = useState("New York City");
   const [results, setResults] = useState(null);
 
   useEffect(() => {
-    fetch("https://api.openweathermap.org/data/2.5/weather?q=" + city + "&units=metric" + "&appid=" + process.env.REACT_APP_APIKEY)
-      .then(res => res.json())
+    fetch(
+      "https://api.openweathermap.org/data/2.5/weather?q=" +
+        city +
+        "&units=metric" +
+        "&appid=" +
+        process.env.REACT_APP_APIKEY
+    )
+      .then((res) => res.json())
       .then(
         (result) => {
-          if (result['cod'] !== 200) {
-            setIsLoaded(false)
+          if (result["cod"] !== 200) {
+            setIsLoaded(false);
           } else {
             setIsLoaded(true);
             setResults(result);
@@ -24,31 +31,40 @@ function App() {
           setIsLoaded(true);
           setError(error);
         }
-      )
-  }, [city])
+      );
+  }, [city]);
 
   if (error) {
     return <div>Error: {error.message}</div>;
   } else {
-    return <>
-      <img className="logo" src={logo} alt="MLH Prep Logo"></img>
-      <div>
-        <h2>Enter a city below 👇</h2>
-        <input
-          type="text"
-          value={city}
-          onChange={event => setCity(event.target.value)} />
-        <div className="Results">
-          {!isLoaded && <h2>Loading...</h2>}
-          {console.log(results)}
-          {isLoaded && results && <>
-            <h3>{results.weather[0].main}</h3>
-            <p>Feels like {results.main.feels_like}°C</p>
-            <i><p>{results.name}, {results.sys.country}</p></i>
-          </>}
+    return (
+      <>
+        <img className="logo" src={logo} alt="MLH Prep Logo"></img>
+        <div>
+          <h2>Enter a city below 👇</h2>
+          <input
+            type="text"
+            value={city}
+            onChange={(event) => setCity(event.target.value)}
+          />
+          <div className="Results">
+            {!isLoaded && <h2>Loading...</h2>}
+            {console.log(results)}
+            {isLoaded && results && (
+              <>
+                <h3>{results.weather[0].main}</h3>
+                <p>Feels like {results.main.feels_like}°C</p>
+                <i>
+                  <p>
+                    {results.name}, {results.sys.country}
+                  </p>
+                </i>
+              </>
+            )}
+          </div>
         </div>
-      </div>
-    </>
+      </>
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
I along with @Tanmay000009 have brainstormed about various ways through which #12 can be resolved.
Currently, we're facing an issue with how searches function, which is blocking us from making a successful PR.

## Details
The issue is that currently, each search happens when a `change` event is triggered on the `input` field. But with this keeping track of successful searches, and hence maintaining the list of several previous searches becomes difficult, because the API returns us a city, even if the current combination doesn't make up a valid one, since it returns the city which starts with that character sequence. This is preventing us from keeping an accurate track of the cities that users actually searched for.

## Related issues
Also as we suggested [here](https://github.com/MLH-Fellowship/prep-project-4.1.1/issues/12#issuecomment-943187388) that issue #6 can use our data if the input fields are empty.