### PR TITLE
Remove an overlapping search box

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,7 +25,6 @@ input {
   border: none;
   padding: 0 10px;
   position: relative;
-  top: 12.5px;
   cursor: pointer;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -119,11 +119,6 @@ function App() {
 
   const getWeather = () => setCity(searchCity);
 
-  const searchOnEnter = (event) => {
-    if (event.key === "Enter") getWeather();
-  };
-
-
   useEffect(() => {
     if (coordinates) {
       fetch(
@@ -171,16 +166,6 @@ function App() {
             src={weather[0]}
           />
           <h2>Enter a city below 👇</h2>
-          <input
-            type="text"
-            value={searchCity}
-            onChange={(event) => setSearchCity(event.target.value)}
-            onKeyPress={searchOnEnter}
-          />
-          <button className="search-btn" onClick={getWeather}>
-            <img className="search-logo" alt="Search" src={searchIcon} />
-          </button>
-
           <div id="city-typeahead-container">
             <PlacesTypeahead
               apiKey={process.env.REACT_APP_API_NINJAS_API_KEY}
@@ -190,7 +175,11 @@ function App() {
               onKeyDown={(event) =>
                 event.key === "Enter" && setCity(event.target.value)
               }
+              onSearch={setSearchCity}
             />
+            <button className="search-btn" onClick={getWeather}>
+              <img className="search-logo" alt="Search" src={searchIcon} />
+            </button>
             <button
               type="submit"
               className={showGraph ? "toggle-graph active" : "toggle-graph"}

--- a/src/components/PlacesTypeahead.js
+++ b/src/components/PlacesTypeahead.js
@@ -12,6 +12,7 @@ export default function PlacesTypeahead(props) {
   const [selected, setSelected] = useState([]);
 
   const handleSearch = query => {
+    props.onSearch(query);
     setIsLoading(true);
     fetch(`${SEARCH_URI}?name=${escape(query)}&limit=${LIMIT}`, {
       method: "GET",
@@ -42,6 +43,7 @@ export default function PlacesTypeahead(props) {
       useCache
       onSearch={handleSearch}
       onChange={handleChange}
+      onKeyDown={props.onKeyDown}
       selected={selected}
       options={options}
       placeholder="Enter City Name..."


### PR DESCRIPTION
## Details
- Remove an overlapping search box and keep only the search box that can do auto-completion.
- Reposition the search button to the right of the search box.
- Adjust minor CSS for the search button.
- `onKeyDown` event handler for the search box to invoke `setCity` on `Enter` being pressed.
- Adjust code logic so that the search button can work with the search box.

Co-authored by: @ShiviPro.

## Related issues
This resolves #34.
This also addresses a point mentioned in #12.